### PR TITLE
Support PyTorch>=1.0; Replace scipy.io with h5py; Avoid empty results when doing NMS

### DIFF
--- a/layers/functions/detection.py
+++ b/layers/functions/detection.py
@@ -70,6 +70,8 @@ class Detect(Function):
                     continue
                 l_mask = c_mask.unsqueeze(1).expand_as(decoded_boxes)
                 boxes = decoded_boxes[l_mask].view(-1, 4)
+                if boxes.shape[0] == 0:
+                    continue
                 # idx of highest scoring and non-overlapping boxes per class
                 #t3 = time.time()
                 ids, count = nms(boxes, scores, self.nms_thresh, self.top_k)

--- a/light_face_ssd.py
+++ b/light_face_ssd.py
@@ -219,7 +219,7 @@ class SSD(nn.Module):
         
     def init_priors(self ,cfg , min_size=cfg['min_sizes'], max_size=cfg['max_sizes']):
         priorbox = PriorBox(cfg , min_size, max_size)
-        prior = Variable ( priorbox.forward() , volatile=True)
+        prior = Variable(priorbox.forward())
         return prior
         
     def forward(self, x):
@@ -380,11 +380,11 @@ class SSD(nn.Module):
 
     def _upsample_add(self, x, y):
         _,_,H,W = y.size()
-        return F.upsample(x, size=(H,W), mode='bilinear') + y
+        return F.interpolate(x, size=(H,W), mode='bilinear', align_corners=True) + y
 
     def _upsample_product(self, x, y):
         _,_,H,W = y.size()
-        return F.upsample(x, size=(H,W), mode='bilinear') * y
+        return F.interpolate(x, size=(H,W), mode='bilinear', align_corners=True) * y
 
 def multibox(input_channels, mbox_cfg, num_classes):
     loc_layers = []

--- a/test.py
+++ b/test.py
@@ -92,7 +92,7 @@ def infer(net , img , transform , thresh , cuda , shrink):
         img = cv2.resize(img, None, None, fx=shrink, fy=shrink, interpolation=cv2.INTER_LINEAR)
 
     x = torch.from_numpy(transform(img)[0]).permute(2, 0, 1)
-    x = Variable(x.unsqueeze(0) , volatile=True)
+    x = x.unsqueeze(0)
     if cuda:
         x = x.cuda()
     y = net(x)      # forward pass
@@ -198,17 +198,18 @@ def light_test_widerface():
     print (thresh)
     save_path = args.save_folder
     num_images = len(testset)
-    for i in range(num_images):
-        img = testset.pull_image(i)
-        img_id, annotation = testset.pull_anno(i)
-        event = testset.pull_event(i)
-        print('Testing image {:d}/{:d} {}....'.format(i+1, num_images , img_id))
-        shrink = 1
-        det = infer(net , img , transform , thresh , cuda , shrink)
-        if not os.path.exists(save_path + event):
-            os.makedirs(save_path + event)
-        f = open(save_path + event + '/' + img_id.split(".")[0] + '.txt', 'w')
-        write_to_txt(f, np.array(det) , event , img_id)
+    with torch.no_grad():
+        for i in range(num_images):
+            img = testset.pull_image(i)
+            img_id, annotation = testset.pull_anno(i)
+            event = testset.pull_event(i)
+            print('Testing image {:d}/{:d} {}....'.format(i+1, num_images , img_id))
+            shrink = 1
+            det = infer(net , img , transform , thresh , cuda , shrink)
+            if not os.path.exists(save_path + event):
+                os.makedirs(save_path + event)
+            f = open(save_path + event + '/' + img_id.split(".")[0] + '.txt', 'w')
+            write_to_txt(f, np.array(det) , event , img_id)
 
 if __name__ == '__main__':
     light_test_oneimage()


### PR DESCRIPTION
Changes are:
- Avoid empty results when doing NMS;
- Replace `scipy.io` with `h5py` to avoid the recommend error for `.mat` version > 7.4;
- Remove deprecated options to support PyTorch>=1.0.

Evaluation results on WIDER Face val with these changes @ `conf_thresh=0.05` and `num_thresh=500` from `data/config.py`:
`easy: 0.891, medium: 0.863, hard: 0.468`